### PR TITLE
Allow Shopware Domain Validation through backend

### DIFF
--- a/rootfs/etc/nginx/sites-enabled/shopware.conf
+++ b/rootfs/etc/nginx/sites-enabled/shopware.conf
@@ -12,6 +12,10 @@ server {
         log_not_found off;
         access_log off;
     }
+    
+    location = /sw-domain-hash.html {
+        try_files $uri /index.php$is_args$args;
+    }
 
     location ~* ^.+\.(?:css|cur|js|jpe?g|gif|ico|png|svg|webp|html)$ {
         expires max;


### PR DESCRIPTION
Shopware's Domain Validation was not possible when using the build in [backend option](https://docs.shopware.com/en/shopware-6-en/settings/system/shopwareaccount?category=shopware-6-en/settings/system) because the [php controller](https://github.com/shopware/platform/blob/95e8bc71aa38cfbdcf088baa779591d7a3196723/src/Storefront/Controller/VerificationHashController.php#L30) was never served by nginx due to the regex static asset location block matching all html routes, too. 

This PR defines a new location block just for this use case: Serve a static file with the name first and falls back to php for `/sw-domain-hash.html`.