### PR TITLE
Fix 500 when using redis cache

### DIFF
--- a/rootfs/etc/shopware/configs/redis.yml
+++ b/rootfs/etc/shopware/configs/redis.yml
@@ -3,14 +3,14 @@ framework:
         app: cache.adapter.redis
         system: cache.adapter.redis
         pools:
-            serializer:
+            cache.serializer:
                 adapter: cache.adapter.redis
-            annotations:
+            cache.annotations:
                 adapter: cache.adapter.redis
-            property_info:
+            cache.property_info:
                 adapter: cache.adapter.redis
-            messenger:
+            cache.messenger:
                 adapter: cache.adapter.redis
-            property_access:
+            cache.property_access:
                 adapter: cache.adapter.redis
         default_redis_provider: "redis://%env(REDIS_CACHE_HOST)%:%env(REDIS_CACHE_PORT)%/%env(REDIS_CACHE_DATABASE)%"


### PR DESCRIPTION
According to your post in https://forum.shopware.com/t/redis-adapter-problem-nach-shopware-6-update-von-6-7-4-auf-6-4-8-1/93031/5 this need to be changed to fix 500 errors after updaten shopware