### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,4 @@
-import * as semver from "https://deno.land/x/semver/mod.ts";
+import * as semver from "https://deno.land/std/semver/mod.ts";
 
 async function main() {
     let releases = await getReleases();


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver